### PR TITLE
Fix for type errors

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -465,9 +465,9 @@
   when: use_aide|bool
   cron:
     name: "run AIDE check"
-    minute: 05
-    hour: 04
-    weekday: 0
+    minute: '05'
+    hour: '04'
+    weekday: '0'
     user: root
     job: "/usr/sbin/aide --check"
   tags:


### PR DESCRIPTION
 [WARNING]: The value 5 (type int) in a string field was converted to u'5' (type string). If this does not look like
what you expect, quote the entire value to ensure it does not change.

 [WARNING]: The value 4 (type int) in a string field was converted to u'4' (type string). If this does not look like
what you expect, quote the entire value to ensure it does not change.

 [WARNING]: The value 0 (type int) in a string field was converted to u'0' (type string). If this does not look like
what you expect, quote the entire value to ensure it does not change.